### PR TITLE
macos m1 需要在bazel的WORKSPACE中将gtest版本调整为1.12.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# vscode
+.vscode

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -4,5 +4,5 @@ new_git_repository(
     name = "googletest",
     build_file = "@//:gmock.BUILD",
     remote = "https://github.com/google/googletest",
-    tag = "release-1.10.0",
+    tag = "release-1.12.1",
 )


### PR DESCRIPTION
1.10.0版本会出现`error: unknown type name 'Int32'`问题
参考https://github.com/google/googletest/issues/4061